### PR TITLE
fix: restore both AS degrees from New Hampshire Community College

### DIFF
--- a/data.js
+++ b/data.js
@@ -210,6 +210,7 @@ window.RESUME = {
   education: [
     { degree: "MBA, Information Systems", school: "Southern New Hampshire University", time: "2010 — 2011" },
     { degree: "BS, Technical Management", school: "Southern New Hampshire University", time: "2008 — 2009" },
+    { degree: "AS, Automotive Technology", school: "New Hampshire Community College", time: "2004 — 2008" },
     { degree: "AS, Small Business Management", school: "New Hampshire Community College", time: "2004 — 2008" }
   ],
 


### PR DESCRIPTION
## Summary
- Restores AS, Automotive Technology and AS, Small Business Management — both were earned but only one survived the previous modernization rewrite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)