### PR TITLE
fix: hide PDF sidebar links in all print/export modes

### DIFF
--- a/App.jsx
+++ b/App.jsx
@@ -158,6 +158,10 @@ function App() {
     window.printResume = (mode) => {
       const m = mode || "full";
       document.documentElement.setAttribute("data-print", m);
+      // hide PDF sidebar links — useless in any printed/exported document
+      document.querySelectorAll(".contact-list li.pdf").forEach((el) => {
+        el.style.setProperty("display", "none", "important");
+      });
       // fill skill bars / rings in case the user hasn't scrolled them into view yet
       document.querySelectorAll(".sk-fill").forEach((f) => {
         if (f.dataset.level) f.style.width = f.dataset.level + "%";
@@ -207,6 +211,9 @@ function App() {
     };
     const after = () => {
       document.documentElement.removeAttribute("data-print");
+      document.querySelectorAll(".contact-list li.pdf").forEach((el) => {
+        el.style.removeProperty("display");
+      });
       const s = window.__printStyleTag;
       if (s) { s.remove(); window.__printStyleTag = null; }
     };

--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
 <link rel="stylesheet" href="colors_and_type.css">
 <link rel="stylesheet" href="kit.css">
 <link rel="stylesheet" href="skills.css">
-<link rel="stylesheet" href="print.css">
+<link rel="stylesheet" href="print.css?v=2">
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css">
 <script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
 <script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>

--- a/print.css
+++ b/print.css
@@ -7,7 +7,7 @@
   html, body { background: #fff !important; }
   body { font-size: 9.5pt; }
 
-  /* hide app chrome + live clock (useless / space-wasting in PDF) */
+  /* hide app chrome + live clock */
   .topbar, .cmdk-backdrop, .twk-panel, [data-omelette-chrome],
   .exp-expand, .filters, .status-dot, .section-rule,
   .clock-card { display: none !important; }
@@ -73,6 +73,9 @@
 /* Single-page layout rules applied ON-SCREEN when data-print="single" is set so that
    JS can measure the true print-mode height before injecting the @page size. */
 html[data-print="single"] body { font-size: 9.5pt !important; }
+/* PDF sidebar links are useless in any printed/exported document */
+html[data-print] .contact-list li.pdf { display: none !important; }
+
 html[data-print="single"] .topbar,
 html[data-print="single"] .cmdk-backdrop,
 html[data-print="single"] .twk-panel,
@@ -80,7 +83,8 @@ html[data-print="single"] .exp-expand,
 html[data-print="single"] .filters,
 html[data-print="single"] .status-dot,
 html[data-print="single"] .section-rule,
-html[data-print="single"] .clock-card { display: none !important; }
+html[data-print="single"] .clock-card,
+html[data-print="single"] .contact-list li.pdf { display: none !important; }
 html[data-print="single"] .resume-shell {
   margin: 0 !important; max-width: 100% !important;
   border: none !important; border-radius: 0 !important; box-shadow: none !important;


### PR DESCRIPTION
## Summary
- Hides the "Printer-friendly PDF", "Enhanced PDF", and "Single-page PDF" sidebar links during any print/export (they're circular and waste sidebar space in a printed document)
- Applied via JS in `printResume()` so it works regardless of browser CSS cache state
- Links are restored after print via the `afterprint` event

🤖 Generated with [Claude Code](https://claude.com/claude-code)